### PR TITLE
feat: typescript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@greenwood/plugin-adapter-vercel": "^0.33.1",
         "@greenwood/plugin-css-modules": "^0.33.1",
         "@greenwood/plugin-import-raw": "^0.33.1",
-        "typescript": "^5.8.0"
+        "typescript": "^6.0.0-beta"
       }
     },
     "node_modules/@greenwood/cli": {
@@ -2925,10 +2925,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "6.0.0-beta",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.0-beta.tgz",
+      "integrity": "sha512-CldZdztDpQRLM1HC6WDQjQkQN5Ub5zRau737a1diGh3lPmb9oRsaWHk1y5iqK0o7+1bNJ0oXfEGRkAogFZBL+Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
     "@greenwood/plugin-adapter-vercel": "^0.33.1",
     "@greenwood/plugin-css-modules": "^0.33.1",
     "@greenwood/plugin-import-raw": "^0.33.1",
-    "typescript": "^5.8.0"
+    "typescript": "^6.0.0-beta"
   }
 }

--- a/src/components/logo/logo.ts
+++ b/src/components/logo/logo.ts
@@ -13,13 +13,15 @@ template.innerHTML = `
   </div>
 `;
 
-export default class Logo extends HTMLElement {
+export default class Logo extends HTMLElement {  
+  shadowRoot: ShadowRoot | null = this.shadowRoot;
+  
   connectedCallback() {
     if (!this.shadowRoot) {
       const message: string = "Message from logo component";
       console.log({ message });
 
-      this.attachShadow({ mode: "open" });
+      this.shadowRoot = this.attachShadow({ mode: "open" });
       this.shadowRoot?.appendChild(template.content.cloneNode(true));
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "verbatimModuleSyntax": true,
     "erasableSyntaxOnly": true,
+    "skipLibCheck": true
   },
 
   "exclude": ["./public/", "./greenwood/", "node_modules"],


### PR DESCRIPTION
The TypeScript 6 (Beta) is out!  👀 
https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/

SSR / WCC and everything else looks to still be working great

<img width="1901" height="745" alt="Screenshot 2026-02-24 at 9 50 46 PM" src="https://github.com/user-attachments/assets/385ba2b7-fc8c-41c9-9821-932dfe03cba8" />
<img width="1684" height="377" alt="Screenshot 2026-02-24 at 9 50 20 PM" src="https://github.com/user-attachments/assets/a03d8c77-babc-4ea9-8565-40624a093a9c" />

----

Initial `tsc` check resulted in the following
```sh
➜  greenwood-native-typescript git:(master) ✗ npm run lint

> greenwood-native-typescript@1.0.0 lint
> tsc

node_modules/rollup/dist/rollup.d.ts:922:10 - error TS2550: Property 'asyncDispose' does not exist on type 'SymbolConstructor'. Do you need to change your target library? Try changing the 'lib' compiler option to 'esnext' or later.

922  [Symbol.asyncDispose](): Promise<void>;
             ~~~~~~~~~~~~

src/components/logo/logo.ts:23:24 - error TS2339: Property 'appendChild' does not exist on type 'never'.

23       this.shadowRoot?.appendChild(template.content.cloneNode(true));
                          ~~~~~~~~~~~

src/components/logo/logo.ts:26:5 - error TS2531: Object is possibly 'null'.

26     this.shadowRoot.adoptedStyleSheets = [logoSheet];
       ~~~~~~~~~~~~~~~


Found 3 errors in 2 files.

Errors  Files
     1  node_modules/rollup/dist/rollup.d.ts:922
     2  src/components/logo/logo.ts:23
```